### PR TITLE
Add gawk & grep

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -386,6 +386,16 @@ install_make() {
    cd ..
 }
 
+install_grep() {
+   cd "$GREP_SRC" &&
+   ./configure --prefix="$SYS_ROOT" \
+      --build="$HOST" \
+      --host="$TARGET" &&
+   make -j$PROCS &&
+   make install &&
+   cd ..
+}
+
 cd "$SYSTEM"/src &&
    install_zlib &&
    install_gpg_error &&
@@ -409,5 +419,6 @@ cd "$SYSTEM"/src &&
    install_ncurses &&
    install_vim &&
    install_make &&
+   install_grep &&
    print_info "compile.sh finished successfully" &&
    exit 0

--- a/compile.sh
+++ b/compile.sh
@@ -396,6 +396,16 @@ install_grep() {
    cd ..
 }
 
+install_gawk() {
+   cd "$GAWK_SRC" &&
+   ./configure --prefix="$SYS_ROOT" \
+      --build="$HOST" \
+      --host="$TARGET" &&
+   make -j$PROCS &&
+   make install &&
+   cd ..
+}
+
 cd "$SYSTEM"/src &&
    install_zlib &&
    install_gpg_error &&
@@ -420,5 +430,6 @@ cd "$SYSTEM"/src &&
    install_vim &&
    install_make &&
    install_grep &&
+   install_gawk &&
    print_info "compile.sh finished successfully" &&
    exit 0

--- a/download-funcs.sh
+++ b/download-funcs.sh
@@ -23,6 +23,7 @@ VIM_URL=ftp://ftp.vim.org/pub/vim/unix/"$VIM_PKG"
 GPG_ERROR_URL=ftp://ftp.gnupg.org/gcrypt/libgpg-error/"$GPG_ERROR_PKG"
 GCRYPT_URL=ftp://ftp.gnupg.org/gcrypt/libgcrypt/"$GCRYPT_PKG"
 MAKE_URL=ftp://ftp.gnu.org/gnu/make/"$MAKE_PKG"
+GREP_URL=https://ftp.gnu.org/gnu/grep/"$GREP_PKG"
 
 unpack () {
    if [ -d "$3" ]; then
@@ -187,4 +188,12 @@ download_grub () {
   pushd $GRUB_SRC &&
   apply_patch $SCRIPT_DIR/patches/grub/fix-build.patch 1 &&
   popd
+}
+
+download_grep () {
+  download $GREP_PKG $GREP_URL &&
+  if [ -d "$GREP_SRC" ]; then
+    return 0
+  fi
+  unpack xf $GREP_PKG $GREP_SRC
 }

--- a/download-funcs.sh
+++ b/download-funcs.sh
@@ -24,6 +24,7 @@ GPG_ERROR_URL=ftp://ftp.gnupg.org/gcrypt/libgpg-error/"$GPG_ERROR_PKG"
 GCRYPT_URL=ftp://ftp.gnupg.org/gcrypt/libgcrypt/"$GCRYPT_PKG"
 MAKE_URL=ftp://ftp.gnu.org/gnu/make/"$MAKE_PKG"
 GREP_URL=https://ftp.gnu.org/gnu/grep/"$GREP_PKG"
+GAWK_URL=https://ftp.gnu.org/gnu/gawk/"$GAWK_PKG"
 
 unpack () {
    if [ -d "$3" ]; then
@@ -196,4 +197,12 @@ download_grep () {
     return 0
   fi
   unpack xf $GREP_PKG $GREP_SRC
+}
+
+download_gawk () {
+  download $GAWK_PKG $GAWK_URL &&
+    if [ -d "$GAWK_SRC" ]; then
+      return 0
+    fi
+    unpack xf $GAWK_PKG $GAWK_SRC
 }

--- a/download.sh
+++ b/download.sh
@@ -50,6 +50,7 @@ download_gpg_error &&
 download_gcrypt &&
 
 download_make &&
+download_grep &&
 
 download_sed &&
 echo "Download complete."

--- a/download.sh
+++ b/download.sh
@@ -51,6 +51,7 @@ download_gcrypt &&
 
 download_make &&
 download_grep &&
+download_gawk &&
 
 download_sed &&
 echo "Download complete."

--- a/vars.sh
+++ b/vars.sh
@@ -39,6 +39,7 @@ VIM_VERSION=7.4
 GPG_ERROR_VERSION=1.36
 GCRYPT_VERSION=1.8.6
 MAKE_VERSION=4.3
+GREP_VERSION=3.6
 # Mach, Hurd and Glibc are all taken from the Git repository.
 
 BINUTILS_SRC=binutils-"$BINUTILS_VERSION"
@@ -87,6 +88,8 @@ GCRYPT_SRC=libgcrypt-"$GCRYPT_VERSION"
 GCRYPT_PKG=${GCRYPT_SRC}.tar.bz2
 MAKE_SRC=make-"$MAKE_VERSION"
 MAKE_PKG=${MAKE_SRC}.tar.gz
+GREP_SRC=grep-"$GREP_VERSION"
+GREP_PKG=${GREP_SRC}.tar.xz
 
 print_info ()
 {

--- a/vars.sh
+++ b/vars.sh
@@ -40,6 +40,7 @@ GPG_ERROR_VERSION=1.36
 GCRYPT_VERSION=1.8.6
 MAKE_VERSION=4.3
 GREP_VERSION=3.6
+GAWK_VERSION=5.1.0
 # Mach, Hurd and Glibc are all taken from the Git repository.
 
 BINUTILS_SRC=binutils-"$BINUTILS_VERSION"
@@ -90,6 +91,8 @@ MAKE_SRC=make-"$MAKE_VERSION"
 MAKE_PKG=${MAKE_SRC}.tar.gz
 GREP_SRC=grep-"$GREP_VERSION"
 GREP_PKG=${GREP_SRC}.tar.xz
+GAWK_SRC=gawk-"$GAWK_VERSION"
+GAWK_PKG=${GAWK_SRC}.tar.xz
 
 print_info ()
 {


### PR DESCRIPTION
`./configure` scripts like to have gawk & grep, and bootstrapping them without those tools is also quite annoying as both use autotools and as such depend on these tools.

Cross-compiling these tools solves that.