### PR TITLE
Added a script to update all config.guess and config.sub.

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -2,6 +2,7 @@
 
 . ./vars.sh
 . ./download-funcs.sh
+. ./update-configs.sh
 
 mkdir -p $SOURCE &&
   pushd $SOURCE &&
@@ -72,4 +73,7 @@ mkdir -p $SOURCE &&
   download_libacpica &&
   download_rumpkernel &&
   download_binutils_gdb &&
-  echo "Download complete."
+  echo "Download complete." &&
+  update_configs_in_dir "$SOURCE" &&
+  update_configs_in_dir "$DOWNLOAD_CACHE_DIRECTORY" &&
+  echo "Update config.guess and config.sub complete."

--- a/update-configs.sh
+++ b/update-configs.sh
@@ -1,0 +1,24 @@
+CONFIG_GUESS_URL="https://git.savannah.gnu.org/cgit/config.git/plain/config.guess"
+CONFIG_SUB_URL="https://git.savannah.gnu.org/cgit/config.git/plain/config.sub"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+wget -O "$TMPDIR/config.guess" "$CONFIG_GUESS_URL"
+wget -O "$TMPDIR/config.sub" "$CONFIG_SUB_URL"
+
+if [ ! -s "$TMPDIR/config.guess" ] || [ ! -s "$TMPDIR/config.sub" ]; then
+  echo "Error: Failed to download config.guess or config.sub"
+  exit 1
+fi
+
+update_configs_in_dir() {
+  local dir="$1"
+  if [ -d "$dir" ]; then
+    find "$dir" -type f \( -name "config.guess" -o -name "config.sub" \) | while read -r f; do
+      base=$(basename "$f")
+      cp -f "$TMPDIR/$base" "$f"
+      chmod +x "$f"
+    done
+  fi
+}


### PR DESCRIPTION
An update-configs.sh script was added to update all config.guess and config.sub files, because in some sources these configuration files were too old and did not know about new architectures (for example, RISC-V).